### PR TITLE
added baseline MVO

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -10,9 +10,9 @@ if __name__ == "__main__":
     fetcher = StockDataFetcher(file_path, "c9390a380f1c33649e759b91b864853d")
 
     # Collect and handle stock data
-    fetcher.fetch_stock_data(start_date="2000-01-01", end_date="2023-12-31")
+    fetcher.fetch_stock_data(start_date="2000-01-01", end_date="2022-06-01")
     stock_data = fetcher.get_stock_data()
-    fetcher.fetch_economic_data(start_date="2000-01-01", end_date="2023-12-31")
+    fetcher.fetch_economic_data(start_date="2000-01-01", end_date="2022-06-01")
     econ_data = fetcher.get_economic_data()
 
     # Flatten the MultiIndex columns in stock_data
@@ -35,8 +35,8 @@ if __name__ == "__main__":
         joblib.dump(predictor.models[ticker], f"models/{ticker}_model.pkl")
 
     # Collect application data
-    application_start_date = "2023-10-15"
-    application_end_date = "2024-03-31"  # Adjust this as needed
+    application_start_date = "2022-06-01"
+    application_end_date = "2023-05-31"
     fetcher.fetch_stock_data(start_date=application_start_date, end_date=application_end_date)
     application_stock_data = fetcher.get_stock_data()
     fetcher.fetch_economic_data(start_date=application_start_date, end_date=application_end_date)
@@ -59,9 +59,23 @@ if __name__ == "__main__":
     predicted_prices_df = predictor.predict_future(application_data)
 
     # Portfolio Optimization with MVOModel
-    optimizer = PortfolioOptimizer(predicted_prices_df, max_volatility=0.8)
+    optimizer = PortfolioOptimizer(predicted_prices_df, max_volatility=1)
     optimal_weights = optimizer.get_optimal_weights()
     print("Optimal Portfolio Weights:", optimal_weights['Weights'])
     print("Optimal Portfolio Return:", optimal_weights['Return'])
     print("Optimal Portfolio Volatility:", optimal_weights['Volatility'])
     print("Optimal Portfolio Sharpe Ratio:", optimal_weights['Sharpe Ratio'])
+
+    # Baseline MVO Model using historical prices
+    historical_prices_df = application_data[[col for col in application_data.columns
+                                             if col.endswith('_Close')]].copy()
+    historical_prices_df.columns = [col.replace('_Close', '') for col in
+                                    historical_prices_df.columns]  # Simplify column names
+
+    # Portfolio Optimization with the baseline MVO model
+    baseline_optimizer = PortfolioOptimizer(historical_prices_df, max_volatility=1)
+    baseline_optimal_weights = baseline_optimizer.get_optimal_weights()
+    print("Baseline Optimal Portfolio Weights:", baseline_optimal_weights['Weights'])
+    print("Baseline Optimal Portfolio Return:", baseline_optimal_weights['Return'])
+    print("Baseline Optimal Portfolio Volatility:", baseline_optimal_weights['Volatility'])
+    print("Baseline Optimal Portfolio Sharpe Ratio:", baseline_optimal_weights['Sharpe Ratio'])

--- a/src/tests/InvestmentSimulator.py
+++ b/src/tests/InvestmentSimulator.py
@@ -28,12 +28,12 @@ class PortfolioEvaluator:
 
 
 if __name__ == "__main__":
-    allocations = {'MSFT': 0.06163007969463202, 'GOOGL': 0.14202126437609114, 'VFV.TO': 8.900025051520374e-16,
-                   'AMZN': 0.01523047596549252, 'NFLX': 2.7405751008412887e-18, 'TSLA': 0.5153290502440645,
-                   'META': 0.07634978341321792, 'NVDA': 0.030773078323741564, 'AAPL': 0.15866626798275946}
+    allocations = {'MSFT': 0.0, 'AAPL': 9.322792424702106e-16, 'VFV.TO': 4.95473227694169e-16,
+                   'GOOGL': 0.21890883215046894, 'NFLX': 0.42167636626372723, 'TSLA': 0.28382925313290774,
+                   'META': 4.0075965359051273e-16, 'NVDA': 0.0755855484528945, 'AMZN': 1.5655231422342987e-16}
 
     evaluator = PortfolioEvaluator(allocations)
-    start_date = '2024-01-16'
-    end_date = '2024-03-28'
+    start_date = '2023-06-01'
+    end_date = '2024-05-25'
     actual_return = evaluator.evaluate_performance(start_date, end_date)
     print(f"Actual Portfolio Return from {start_date} to {end_date}: {actual_return * 100:.2f}%")


### PR DESCRIPTION
added a code in main.py to create a baseline MVO model that uses historical prices as input. Will be used to compare with MVO model that uses predicted prices with different ranges (21, 126, and 252) forward looking prediction days.